### PR TITLE
LoudnessWindow FORWARD_NULL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+* text eol=crlf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# macOS
+.DS_Store

--- a/DSPiConsole/LoudnessWindow.xaml.cs
+++ b/DSPiConsole/LoudnessWindow.xaml.cs
@@ -28,9 +28,10 @@ public sealed partial class LoudnessWindow : Window
         // Set window size and dark titlebar
         var hWnd = WindowNative.GetWindowHandle(this);
         var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
-        var appWindow = AppWindow.GetFromWindowId(windowId);
-        appWindow?.Resize(new Windows.Graphics.SizeInt32(400, 600));
-        appWindow!.Title = "Loudness Compensation";
+        var appWindow = AppWindow.GetFromWindowId(windowId) ??
+            throw new InvalidOperationException("AppWindow not available");
+        appWindow.Resize(new Windows.Graphics.SizeInt32(400, 600));
+        appWindow.Title = "Loudness Compensation";
 
         if (appWindow.TitleBar is { } titleBar)
         {


### PR DESCRIPTION
See https://scan5.scan.coverity.com/#/project-view/66416/10731?selectedIssue=1682109

       // Set window size and dark titlebar
 29        var hWnd = WindowNative.GetWindowHandle(this);
 30        var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
 31        var appWindow = AppWindow.GetFromWindowId(windowId);
     	1. Condition appWindow, taking false branch.
     	2. var_compare_op: Comparing appWindow to null implies that appWindow might be null.
 32        appWindow?.Resize(new Windows.Graphics.SizeInt32(400, 600));
     	
CID 1682109: (#1 of 1): Dereference after null check (FORWARD_NULL)
3. null_method_call: Calling a method on null object appWindow.
 33        appWindow!.Title = "Loudness Compensation";