### PR TITLE
CrossfeedWindow FORWARD_NULL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+* text eol=crlf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# macOS
+.DS_Store

--- a/DSPiConsole/CrossfeedWindow.xaml.cs
+++ b/DSPiConsole/CrossfeedWindow.xaml.cs
@@ -44,9 +44,10 @@ public sealed partial class CrossfeedWindow : Window
         // Set window size and dark titlebar (380x560)
         var hWnd = WindowNative.GetWindowHandle(this);
         var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
-        var appWindow = AppWindow.GetFromWindowId(windowId);
-        appWindow?.Resize(new Windows.Graphics.SizeInt32(380, 560));
-        appWindow!.Title = "Crossfeed";
+        var appWindow = AppWindow.GetFromWindowId(windowId) ??
+            throw new InvalidOperationException("AppWindow not available");
+        appWindow.Resize(new Windows.Graphics.SizeInt32(380, 560));
+        appWindow.Title = "Crossfeed";
 
         if (appWindow.TitleBar is { } titleBar)
         {


### PR DESCRIPTION
See https://scan5.scan.coverity.com/#/project-view/66416/10731?selectedIssue=1682108

        var hWnd = WindowNative.GetWindowHandle(this);
 46        var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
 47        var appWindow = AppWindow.GetFromWindowId(windowId);
     	1. Condition appWindow, taking false branch.
     	2. var_compare_op: Comparing appWindow to null implies that appWindow might be null.
 48        appWindow?.Resize(new Windows.Graphics.SizeInt32(380, 560));
     	
CID 1682108: (#1 of 1): Dereference after null check (FORWARD_NULL)
3. null_method_call: Calling a method on null object appWindow.
 49        appWindow!.Title = "Crossfeed";