### PR TITLE
MatrixMixerWindow FORWARD_NULL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+* text eol=crlf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# macOS
+.DS_Store

--- a/DSPiConsole/CrossfeedWindow.xaml.cs
+++ b/DSPiConsole/CrossfeedWindow.xaml.cs
@@ -44,9 +44,10 @@ public sealed partial class CrossfeedWindow : Window
         // Set window size and dark titlebar (380x560)
         var hWnd = WindowNative.GetWindowHandle(this);
         var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
-        var appWindow = AppWindow.GetFromWindowId(windowId);
-        appWindow?.Resize(new Windows.Graphics.SizeInt32(380, 560));
-        appWindow!.Title = "Crossfeed";
+        var appWindow = AppWindow.GetFromWindowId(windowId) ??
+            throw new InvalidOperationException("AppWindow not available");
+        appWindow.Resize(new Windows.Graphics.SizeInt32(380, 560));
+        appWindow.Title = "Crossfeed";
 
         if (appWindow.TitleBar is { } titleBar)
         {

--- a/DSPiConsole/MatrixMixerWindow.xaml.cs
+++ b/DSPiConsole/MatrixMixerWindow.xaml.cs
@@ -56,9 +56,10 @@ public sealed partial class MatrixMixerWindow : Window
 
         var hWnd = WindowNative.GetWindowHandle(this);
         var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
-        var appWindow = AppWindow.GetFromWindowId(windowId);
+        var appWindow = AppWindow.GetFromWindowId(windowId) ??
+            throw new InvalidOperationException("Failed to retrieve AppWindow");
 
-        appWindow!.Title = "Matrix Mixer";
+        appWindow.Title = "Matrix Mixer";
 
         // Start at a minimal size so the later ResizeToContent expands rather
         // than shrinking from the OS default — avoids a visible flash.


### PR DESCRIPTION
See https://scan5.scan.coverity.com/#/project-view/66416/10731?selectedIssue=1682107

 57        var hWnd = WindowNative.GetWindowHandle(this);
 58        var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
     	1. returned_null: GetFromWindowId returns null (checked 4 out of 6 times).
     	2. var_assigned: Assigning: appWindow = null return value from GetFromWindowId.
 59        var appWindow = AppWindow.GetFromWindowId(windowId);
 60
     	
CID 1682107: (#1 of 1): Dereference null return value (NULL_RETURNS)
3. null_method_call: Calling a method on null object appWindow.
 61        appWindow!.Title = "Matrix Mixer";