### PR TITLE
StatsWindow FORWARD_NULL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+* text eol=crlf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# macOS
+.DS_Store

--- a/DSPiConsole/CrossfeedWindow.xaml.cs
+++ b/DSPiConsole/CrossfeedWindow.xaml.cs
@@ -44,9 +44,10 @@ public sealed partial class CrossfeedWindow : Window
         // Set window size and dark titlebar (380x560)
         var hWnd = WindowNative.GetWindowHandle(this);
         var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
-        var appWindow = AppWindow.GetFromWindowId(windowId);
-        appWindow?.Resize(new Windows.Graphics.SizeInt32(380, 560));
-        appWindow!.Title = "Crossfeed";
+        var appWindow = AppWindow.GetFromWindowId(windowId) ??
+            throw new InvalidOperationException("AppWindow not available");
+        appWindow.Resize(new Windows.Graphics.SizeInt32(380, 560));
+        appWindow.Title = "Crossfeed";
 
         if (appWindow.TitleBar is { } titleBar)
         {

--- a/DSPiConsole/StatsWindow.xaml.cs
+++ b/DSPiConsole/StatsWindow.xaml.cs
@@ -20,9 +20,10 @@ public sealed partial class StatsWindow : Window
         // Set window size
         var hWnd = WindowNative.GetWindowHandle(this);
         var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
-        var appWindow = AppWindow.GetFromWindowId(windowId);
-        appWindow?.Resize(new Windows.Graphics.SizeInt32(400, 800));
-        appWindow!.Title = "Stats for nerbs";
+        var appWindow = AppWindow.GetFromWindowId(windowId) ??
+            throw new InvalidOperationException("Failed to retrieve AppWindow");
+        appWindow.Resize(new Windows.Graphics.SizeInt32(400, 800));
+        appWindow.Title = "Stats for nerbs";
 
         if (appWindow.TitleBar is { } titleBar)
         {


### PR DESCRIPTION
See https://scan5.scan.coverity.com/#/project-view/66416/10731?selectedIssue=1682106

       var hWnd = WindowNative.GetWindowHandle(this);
22        var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
23        var appWindow = AppWindow.GetFromWindowId(windowId);
    	1. Condition appWindow, taking false branch.
    	2. var_compare_op: Comparing appWindow to null implies that appWindow might be null.
24        appWindow?.Resize(new Windows.Graphics.SizeInt32(400, 800));
    	
CID 1682106: (#1 of 1): Dereference after null check (FORWARD_NULL)
3. null_method_call: Calling a method on null object appWindow.
25        appWindow!.Title = "Stats for nerbs";
26