### PR TITLE
Fix device scan re-entrancy that caused perpetual reconnect churn

### DIFF
--- a/DSPiConsole.Usb/DspDevice.cs
+++ b/DSPiConsole.Usb/DspDevice.cs
@@ -727,6 +727,16 @@ public partial class DspDevice : ObservableObject, IDisposable
         return (0, 0);
     }
 
+    // Guards ScanDevices against re-entrancy. The scan runs on a 500 ms
+    // auto-reset timer, but enumerating and opening a device (list + clone +
+    // open + claim + read serial) can take longer than that interval. Without
+    // this guard the timer re-enters ScanDevices on another thread-pool thread
+    // while a previous scan is still mid-open; the overlapping scans each call
+    // OpenDevice, which tears down any existing connection at entry, so they
+    // repeatedly disconnect the device the previous scan just opened — leaving
+    // it perpetually reconnecting and leaking scan threads.
+    private int _scanActive;
+
     /// <summary>
     /// Scan for all connected DSPi devices, update the available list,
     /// and auto-select/reconnect as needed.
@@ -734,6 +744,10 @@ public partial class DspDevice : ObservableObject, IDisposable
     private void ScanDevices()
     {
         if (_disposed) return;
+
+        // Only one scan at a time (see _scanActive).
+        if (System.Threading.Interlocked.CompareExchange(ref _scanActive, 1, 0) != 0)
+            return;
 
         try
         {
@@ -837,6 +851,10 @@ public partial class DspDevice : ObservableObject, IDisposable
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"ScanDevices error: {ex.Message}");
+        }
+        finally
+        {
+            System.Threading.Interlocked.Exchange(ref _scanActive, 0);
         }
     }
 


### PR DESCRIPTION
## Problem

On some systems the device connects for only a few milliseconds at a time: the sidebar shows the serial but the connection indicator stays red and every feature reports "device not connected", even though USB traffic to the device is healthy. The connection appears to flicker on for a fraction of a second and drop again, roughly once per second.

## Root cause

`ScanDevices` runs on a 500 ms auto-reset `System.Timers.Timer` with no re-entrancy guard. Enumerating and opening a device (`_context.List()` + `Clone()` + `TryOpen` + `ClaimInterface` + read serial) can take longer than 500 ms, so the timer re-enters `ScanDevices` on another thread-pool thread while a previous scan is still mid-open.

Overlapping scans each call `OpenDevice`, and `OpenDevice` tears down any existing connection at entry (`if (_device != null) HandleDisconnect()`). So concurrent scans repeatedly disconnect the device that another scan just opened. The net effect:

- the device is "connected" for only a few ms per cycle, so the UI is effectively always disconnected;
- scan threads pile up unbounded (each blocked on `_lock` behind the others' `OpenDevice`).

This was traced with a USBPcap capture (control transfers complete successfully) plus targeted logging, which showed every `OpenDevice SUCCESS`/`IsConnected=true` immediately followed by a `HandleDisconnect` from a different thread, and a concurrent-scan count climbing without bound.

Because it depends on per-open USB latency crossing the ~500 ms scan interval, it surfaces after an environment change (e.g. a heavily populated USB stack) rather than a code change — the same code was fine when opens were faster.

## Fix

Guard `ScanDevices` with an `Interlocked` flag so only one scan runs at a time. Once a scan connects, the next tick runs alone, takes the already-open fast path, and the connection holds. The flag is cleared in a `finally` so an exception (or the early `return` when already connected) can't leave it stuck.

## Testing

Built and run against V24 firmware on Windows 11: with the guard the device connects on the first scan and stays connected (indicator green, CPU meter live), and the scan-thread pile-up is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
