### PR TITLE
Fix NullReferenceException opening Graphing > Scale settings page

### DIFF
--- a/DSPiConsole/Settings/Pages/GraphingScalePage.xaml.cs
+++ b/DSPiConsole/Settings/Pages/GraphingScalePage.xaml.cs
@@ -50,6 +50,11 @@ public sealed partial class GraphingScalePage : SettingsModule, ISettingsPage
 
     private void OnDbRangeChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
+        // ValueChanged fires during InitializeComponent — setting Minimum="10"
+        // in XAML coerces Value off its 0 default — before the sibling elements
+        // below this slider (DbCenterSlider/DbCenterCard) have been created.
+        // Bail out until the page is fully built to avoid a NullReferenceException.
+        if (DbCenterSlider is null || DbCenterCard is null || DbRangeCard is null) return;
         UpdateRangeDescription(e.NewValue);
         UpdateCenterDescription(DbCenterSlider.Value, e.NewValue);
         Commit(() => AppSettings.Instance.GraphDbRange = e.NewValue);
@@ -57,6 +62,7 @@ public sealed partial class GraphingScalePage : SettingsModule, ISettingsPage
 
     private void OnDbCenterChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
     {
+        if (DbRangeSlider is null || DbCenterCard is null) return;
         UpdateCenterDescription(e.NewValue, DbRangeSlider.Value);
         Commit(() => AppSettings.Instance.GraphDbCenter = e.NewValue);
     }


### PR DESCRIPTION
_Rebased onto `master` (supersedes #11, which auto-closed when `firmware-v20-catchup` was merged)._

## Problem

Opening **Settings → Graphing → Scale** throws a `System.NullReferenceException` and crashes the app.

## Root cause

`DbRangeSlider` has `Minimum="10"` in XAML. During `InitializeComponent`, applying that minimum coerces the slider's `Value` off its default `0`, which fires `OnDbRangeChanged` **before** the sibling elements declared below it (`DbCenterSlider` / `DbCenterCard`) have been created. `OnDbRangeChanged` dereferences `DbCenterSlider`, so it throws.

The existing `_suppress` flag doesn't help here because it's only set during `Refresh()`, not during construction, and the handlers don't check it anyway.

## Fix

Guard the two slider `ValueChanged` handlers against the not-yet-created elements they reference, so the early init-time callback is a no-op. `Refresh()` sets the descriptions explicitly afterward, so nothing is lost.

## Testing

Built and run on Windows 11: the Graphing → Scale page opens normally, and the slider descriptions update correctly when dragged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)